### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol (MCP) server for running AWS Athena queries. This server enables AI assistants to execute SQL queries against your AWS Athena databases and retrieve results.
 
+<a href="https://glama.ai/mcp/servers/0i7dhkex6t">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/0i7dhkex6t/badge" alt="aws-athena-mcp MCP server" />
+</a>
+
 ## Usage
 
 1. Configure AWS credentials using one of the following methods:


### PR DESCRIPTION
This PR adds a badge for the [aws-athena-mcp](https://glama.ai/mcp/servers/0i7dhkex6t) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/0i7dhkex6t">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/0i7dhkex6t/badge" alt="aws-athena-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.