### PR TITLE
Skip first row in query result if query is SELECT only

### DIFF
--- a/src/athena.ts
+++ b/src/athena.ts
@@ -111,6 +111,7 @@ export class AthenaService {
           dataScannedInBytes: response.QueryExecution.Statistics?.DataScannedInBytes || 0,
           engineExecutionTimeInMillis: response.QueryExecution.Statistics?.EngineExecutionTimeInMillis || 0,
         },
+        substatementType: response.QueryExecution.SubstatementType,
       };
     } catch (error) {
       if (error instanceof InvalidRequestException) {
@@ -168,7 +169,7 @@ export class AthenaService {
       ) || [];
 
       const rows = (results.ResultSet.Rows || [])
-        .slice(1) // Skip header row
+        .slice(status.substatementType === 'SELECT' ? 1 : 0) // Skip header row if query is SELECT
         .map((row) => {
           const obj: Record<string, unknown> = {};
           row.Data?.forEach((data, index) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface QueryStatus {
     dataScannedInBytes: number;
     engineExecutionTimeInMillis: number;
   };
+  substatementType: string;
 }
 
 export interface AthenaError {


### PR DESCRIPTION
Hi @lishenxydlgzs,

I got incorrect results when running queries like [Show All Databases](https://github.com/lishenxydlgzs/aws-athena-mcp?tab=readme-ov-file#show-all-databases), [List Tables in a Database](https://github.com/lishenxydlgzs/aws-athena-mcp?tab=readme-ov-file#list-tables-in-a-database), and [Get Table Schema](https://github.com/lishenxydlgzs/aws-athena-mcp?tab=readme-ov-file#get-table-schema), because the first row in their result sets is not a header, unlike in `SELECT` queries. After testing several queries (see below), I found that only `SELECT` statements include a header row in the result set. For more details, refer to [When the Row resultset contains Header](https://github.com/uber/athenadriver/blob/master/resources/UndocumentedAthena.md#when-the-row-resultset-contains-header).

> - DML
>   - SELECT
> - DDL
>   - CREATE_TABLE
>   - DROP_TABLE
> - UTILITY
>   - DESCRIBE_TABLE
>   - SHOW_DATABASES
>   - SHOW_TABLES

  
In this PR, it checks the **SubstatementType** field in the **GetQueryExecution** response to determine whether to treat the first row as a header.