### PR TITLE
Fix type error

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface QueryStatus {
     dataScannedInBytes: number;
     engineExecutionTimeInMillis: number;
   };
-  substatementType: string;
+  substatementType?: string;
 }
 
 export interface AthenaError {


### PR DESCRIPTION
Hi @lishenxydlgzs,

  Apologies for not running the build action prior to pushing. This PR includes a fix for the type error. I've tested it, and it's working as expected now.

```shell
$ npm run build

> @lishenxydlgzs/aws-athena-mcp@1.0.0 build
> tsc && chmod +x build/index.js

src/athena.ts:114:9 - error TS2322: Type 'string | undefined' is not assignable to type 'string'.
  Type 'undefined' is not assignable to type 'string'.

114         substatementType: response.QueryExecution.SubstatementType,
            ~~~~~~~~~~~~~~~~

  src/types.ts:23:3
    23   substatementType: string;
         ~~~~~~~~~~~~~~~~
    The expected type comes from property 'substatementType' which is declared here on type 'QueryStatus'


Found 1 error in src/athena.ts:114
```